### PR TITLE
move tanstack to peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@storybook/addons": "^7.6.17",
     "@storybook/theming": "^8.6.14",
-    "@tanstack/react-query": "^5.90.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-shape": "^3.2.0",
@@ -56,7 +55,8 @@
   "peerDependencies": {
     "react": ">16.8.x",
     "react-dom": ">16.8.x",
-    "react-router": "^7"
+    "react-router": "^7",
+    "@tanstack/react-query": "^5.90.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.3",
@@ -67,6 +67,7 @@
     "@storybook/react": "^8.4.7",
     "@storybook/react-vite": "^8.4.7",
     "@storybook/test": "^8.4.7",
+    "@tanstack/react-query": "^5.90.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Solve #56 

Moved Tanstack to a peer and dev dependency, now when someone installs finch from npm it will use their provided tanstack instead of trying to use an empty finch one which breaks the app.